### PR TITLE
Update AHPagingMenuViewController.m

### DIFF
--- a/Obj-C/AHPagingMenuViewController/AHPagingMenuViewController.m
+++ b/Obj-C/AHPagingMenuViewController/AHPagingMenuViewController.m
@@ -604,8 +604,11 @@
             _currentPage = currentPage;
             if(self.delegate)
             {
-                [self.delegate AHPagingMenuDidChangeMenuPositionFrom:_currentPage to:currentPage];
-                [self.delegate AHPagingMenuDidChangeMenuFrom:[_viewControllers objectAtIndex:_currentPage] to: [_viewControllers objectAtIndex:currentPage]];
+                if ([self.delegate respondsToSelector:@selector(pagingMenuDidChangeMenuPositionFrom:to:)])
+                    [self.delegate pagingMenuDidChangeMenuPositionFrom:_currentPage to:currentPage];
+                
+                if ([self.delegate respondsToSelector:@selector(AHPagingMenuDidChangeMenuFrom:to:)])
+                    [self.delegate AHPagingMenuDidChangeMenuFrom:[_viewControllers objectAtIndex:_currentPage] to: [_viewControllers objectAtIndex:currentPage]];
             }
         }
         


### PR DESCRIPTION
methods of delegate are optional so developer can implement only one of them.In this case application crash.So added additional check on respondToSelector