### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ AHPagingMenuViewController 1.0. Menu Paging like UINavigationController used in 
 ![AHPagingMenuViewController](https://github.com/andrehenrique92/AHPagingMenuViewController/blob/master/assets/icon2.gif)
  
 
-##Installation
+## Installation
 
 1. Add the AHPagingMenuViewController Folder into your project. Easy, easy!
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
